### PR TITLE
make youbot driver compatible with boost 1.49

### DIFF
--- a/youbot/JointLimitMonitor.cpp
+++ b/youbot/JointLimitMonitor.cpp
@@ -104,7 +104,7 @@ void JointLimitMonitor::checkLimitsPositionControl(const quantity<plane_angle>& 
 
       if (!((setpoint < upLimit) && (setpoint > lowLimit))) {
         std::stringstream errorMessageStream;
-        errorMessageStream << "The setpoint angle for joint "<< this->storage.jointName <<" is out of range. The valid range is between " << lowLimit << " and " << upLimit << " and it is: " << setpoint;
+        errorMessageStream << "The setpoint angle for joint "<< this->storage.jointName << " is out of range. The valid range is between " << lowLimit.value() << " and " << upLimit.value() << " and it  is: " << setpoint.value();
         throw std::out_of_range(errorMessageStream.str());
       }
     }

--- a/youbot/YouBotGripperBar.cpp
+++ b/youbot/YouBotGripperBar.cpp
@@ -220,7 +220,7 @@ void YouBotGripperBar::setData(GripperBarPositionSetPoint& barPosition) {
 
     if (barPosition.barPosition > (this->maxTravelDistance + this->barSpacingOffset) || barPosition.barPosition < this->barSpacingOffset) {
       std::stringstream errorMessageStream;
-      errorMessageStream << "The bar position is not allowed to be less than "<< this->barSpacingOffset <<" or higher than " << (this->maxTravelDistance + this->barSpacingOffset) << ". You set " << barPosition.barPosition;
+      errorMessageStream << "The bar position is not allowed to be less than "<< this->barSpacingOffset.value() <<" or higher than " << (this->maxTravelDistance.value() + this->barSpacingOffset.value()) << ". You set " << barPosition.barPosition.value();
       throw std::out_of_range(errorMessageStream.str());
     }
 

--- a/youbot/YouBotGripperParameter.cpp
+++ b/youbot/YouBotGripperParameter.cpp
@@ -224,7 +224,7 @@ void BarSpacingOffset::setParameter(const quantity<si::length>& parameter) {
 void BarSpacingOffset::toString(std::string& value) const {
   // Bouml preserved body begin 0009F1F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009F1F1
 }
@@ -311,7 +311,7 @@ void MaxTravelDistance::setParameter(const quantity<si::length>& parameter) {
 void MaxTravelDistance::toString(std::string& value) const {
   // Bouml preserved body begin 0009F071
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009F071
 }

--- a/youbot/YouBotJointParameter.cpp
+++ b/youbot/YouBotJointParameter.cpp
@@ -181,7 +181,7 @@ void CalibrateJoint::setParameter(const bool doCalibration, CalibrationDirection
 void CalibrateJoint::toString(std::string& value) {
   // Bouml preserved body begin 0009C771
   std::stringstream ss;
-  ss << this->name << ": " << "doCalibration " <<this->doCalibration << " calibrationDirection "<< this->calibrationDirection << " maxCurrent " << this->maxCurrent;
+  ss << this->name << ": " << "doCalibration " <<this->doCalibration << " calibrationDirection "<< this->calibrationDirection << " maxCurrent " << this->maxCurrent.value();
   value  = ss.str();
   // Bouml preserved body end 0009C771
 }
@@ -415,7 +415,7 @@ void JointLimitsRadian::setParameter(const quantity<plane_angle>& lowerLimit, co
 void JointLimitsRadian::toString(std::string& value) {
   // Bouml preserved body begin 000D40F1
   std::stringstream ss;
-  ss << this->name << ": lower Limit: " << this->lowerLimit  << " upper Limit: " << this->upperLimit;
+  ss << this->name << ": lower Limit: " << this->lowerLimit.value()  << " upper Limit: " << this->upperLimit.value();
   value  = ss.str();
   // Bouml preserved body end 000D40F1
 }
@@ -491,7 +491,7 @@ void MaximumPositioningVelocity::setParameter(const quantity<angular_velocity>& 
 void MaximumPositioningVelocity::toString(std::string& value) {
   // Bouml preserved body begin 0009C4F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009C4F1
 }
@@ -550,7 +550,7 @@ void MotorAcceleration::setParameter(const quantity<angular_acceleration>& param
 void MotorAcceleration::toString(std::string& value) {
   // Bouml preserved body begin 0009CCF1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CCF1
 }
@@ -658,7 +658,7 @@ void PositionControlSwitchingThreshold::setParameter(const quantity<angular_velo
 void PositionControlSwitchingThreshold::toString(std::string& value) {
   // Bouml preserved body begin 0009CD71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CD71
 }
@@ -717,7 +717,7 @@ void SpeedControlSwitchingThreshold::setParameter(const quantity<angular_velocit
 void SpeedControlSwitchingThreshold::toString(std::string& value) {
   // Bouml preserved body begin 0009CB71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CB71
 }
@@ -776,7 +776,7 @@ void VelocityThresholdForHallFX::setParameter(const quantity<angular_velocity>& 
 void VelocityThresholdForHallFX::toString(std::string& value) {
   // Bouml preserved body begin 001081F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 001081F1
 }
@@ -1995,7 +1995,7 @@ void MaximumVelocityToSetPosition::setParameter(const quantity<angular_velocity>
 void MaximumVelocityToSetPosition::toString(std::string& value) {
   // Bouml preserved body begin 0009CAF1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CAF1
 }

--- a/youbot/YouBotJointParameterPasswordProtected.cpp
+++ b/youbot/YouBotJointParameterPasswordProtected.cpp
@@ -376,7 +376,7 @@ void CommutationMotorCurrent::setParameter(const quantity<current>& parameter) {
 void CommutationMotorCurrent::toString(std::string& value) {
   // Bouml preserved body begin 0009DCF1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009DCF1
 }
@@ -435,7 +435,7 @@ void CurrentControlLoopDelay::setParameter(const quantity<si::time>& parameter) 
 void CurrentControlLoopDelay::toString(std::string& value) {
   // Bouml preserved body begin 0009CFF1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CFF1
 }
@@ -829,7 +829,7 @@ void InitSineDelay::setParameter(const quantity<si::time>& parameter) {
 void InitSineDelay::toString(std::string& value) {
   // Bouml preserved body begin 0009E3F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009E3F1
 }
@@ -946,7 +946,7 @@ void MaximumMotorCurrent::setParameter(const quantity<current>& parameter) {
 void MaximumMotorCurrent::toString(std::string& value) {
   // Bouml preserved body begin 0009CA71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CA71
 }
@@ -1004,7 +1004,7 @@ void MotorCoilResistance::setParameter(const quantity<resistance>& parameter) {
 void MotorCoilResistance::toString(std::string& value) {
   // Bouml preserved body begin 0009E8F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009E8F1
 }
@@ -1063,7 +1063,7 @@ void MotorControllerTimeout::setParameter(const quantity<si::time>& parameter) {
 void MotorControllerTimeout::toString(std::string& value) {
   // Bouml preserved body begin 0009F871
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009F871
 }
@@ -1185,7 +1185,7 @@ void OperationalTime::setParameter(const quantity<si::time>& parameter) {
 void OperationalTime::toString(std::string& value) {
   // Bouml preserved body begin 000A05F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 000A05F1
 }
@@ -1242,7 +1242,7 @@ void PIDControlTime::setParameter(const quantity<si::time>& parameter) {
 void PIDControlTime::toString(std::string& value) {
   // Bouml preserved body begin 0009CF71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009CF71
 }
@@ -1612,7 +1612,7 @@ void ThermalWindingTimeConstant::setParameter(const quantity<si::time>& paramete
 void ThermalWindingTimeConstant::toString(std::string& value) {
   // Bouml preserved body begin 000A0171
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 000A0171
 }

--- a/youbot/YouBotJointParameterReadOnly.cpp
+++ b/youbot/YouBotJointParameterReadOnly.cpp
@@ -82,7 +82,7 @@ void ActualMotorVoltage::getParameter(quantity<electric_potential>& parameter) c
 void ActualMotorVoltage::toString(std::string& value) {
   // Bouml preserved body begin 0009EC71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009EC71
 }
@@ -253,7 +253,7 @@ void PositionError::getParameter(quantity<plane_angle>& parameter) const {
 void PositionError::toString(std::string& value) {
   // Bouml preserved body begin 0009EDF1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009EDF1
 }
@@ -295,7 +295,7 @@ void PositionErrorSum::getParameter(quantity<plane_angle>& parameter) const {
 void PositionErrorSum::toString(std::string& value) {
   // Bouml preserved body begin 0009EE71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009EE71
 }
@@ -339,7 +339,7 @@ void VelocityError::getParameter(quantity<si::angular_velocity>& parameter) cons
 void VelocityError::toString(std::string& value) {
   // Bouml preserved body begin 0009EEF1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009EEF1
 }
@@ -383,7 +383,7 @@ void VelocityErrorSum::getParameter(quantity<si::angular_velocity>& parameter) c
 void VelocityErrorSum::toString(std::string& value) {
   // Bouml preserved body begin 0009EF71
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009EF71
 }
@@ -428,7 +428,7 @@ void CurrentError::getParameter(quantity<si::current>& parameter) const {
 void CurrentError::toString(std::string& value) {
   // Bouml preserved body begin 000DB071
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 000DB071
 }
@@ -473,7 +473,7 @@ void CurrentErrorSum::getParameter(quantity<si::current>& parameter) const {
 void CurrentErrorSum::toString(std::string& value) {
   // Bouml preserved body begin 000DB471
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 000DB471
 }
@@ -518,7 +518,7 @@ void RampGeneratorSpeed::getParameter(quantity<si::angular_velocity>& parameter)
 void RampGeneratorSpeed::toString(std::string& value) {
   // Bouml preserved body begin 0009F3F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 0009F3F1
 }
@@ -619,7 +619,7 @@ void ActualMotorDriverTemperature::getParameter(quantity<celsius::temperature>& 
 void ActualMotorDriverTemperature::toString(std::string& value) {
   // Bouml preserved body begin 000CB1F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 000CB1F1
 }
@@ -667,7 +667,7 @@ void ActualModuleSupplyCurrent::getParameter(quantity<si::current>& parameter) c
 void ActualModuleSupplyCurrent::toString(std::string& value) {
   // Bouml preserved body begin 000CB5F1
   std::stringstream ss;
-  ss << this->name << ": " << this->value;
+  ss << this->name << ": " << this->value.value();
   value  = ss.str();
   // Bouml preserved body end 000CB5F1
 }


### PR DESCRIPTION
the youbot_driver repository does not compile under boost version 1.49. With the following changes it does. It also still compiles under previous versions, i.e. at least under 1.46.
