### PR TITLE
Fixed error during compilation: 'boost::math has not been declared'

### DIFF
--- a/include/youbot_driver/generic/PidController.hpp
+++ b/include/youbot_driver/generic/PidController.hpp
@@ -36,6 +36,7 @@
 
 
 #include <string>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include "youbot_driver/generic/Time.hpp"
 
 


### PR DESCRIPTION
Whilst attempting to compile this package on Ubuntu 12.04 + ROS Hydro, I came across the error:
`boost::math has not been declared` (specifically when compiling the file `PidController.cpp`).

The simple fix I found was to add the missing header file.
