### PR TITLE
Bugfix for missing include of std:vector

### DIFF
--- a/include/youbot_driver/youbot/EthercatMasterInterface.hpp
+++ b/include/youbot_driver/youbot/EthercatMasterInterface.hpp
@@ -59,6 +59,7 @@ extern "C"{
 #include <nicdrv.h>
 #include <youbot_driver/soem/ethercatmain.h>
 }
+#include<vector>
 
 namespace youbot {
 


### PR DESCRIPTION
Caused an error while compiling.